### PR TITLE
fix : footer 경로 변경

### DIFF
--- a/attendance/src/main/resources/templates/auth.html
+++ b/attendance/src/main/resources/templates/auth.html
@@ -29,7 +29,7 @@
       <button type="submit">확인</button>
     </form>
   </div>
-  <div th:replace="~{/footer :: footer}"></div>
+  <div th:replace="~{footer :: footer}"></div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
# [변경 사항]
- 인증화면이 제대로 로드되지 않고 whiteLabel 에러 페이지가 나옴
- 로그를 보니 footer의 경로가 잘못되었다는 것을 알 수 있었음
> Error resolving template [/footer], template might not exist or might not be accessible
(template: "auth" - line 32, col 8)
