### PR TITLE
feat :  개근정근 정렬 기준 변경, fix : 주석처리하여 계산되지 않았던 model의 주석 삭제 

### DIFF
--- a/attendance/src/main/java/smmiddle/attendance/controller/AttendanceController.java
+++ b/attendance/src/main/java/smmiddle/attendance/controller/AttendanceController.java
@@ -55,7 +55,7 @@ public class AttendanceController {
     model.addAttribute("isSunday", isSunday);
     model.addAttribute("attendanceStatusMap", summary.getAttendanceStatusMap()); // 출석 여부 map
     model.addAttribute("allSubmitted", summary.isAllSubmitted());
-    //model.addAttribute("todayPresentCount", summary.getTodayPresentCount());
+    model.addAttribute("todayPresentCount", summary.getTodayPresentCount()); // 모든 교사가 출석부 제출시 오늘의 총 출석수 조회
     return "select_cell";
   }
 

--- a/attendance/src/main/java/smmiddle/attendance/repository/StudentRepository.java
+++ b/attendance/src/main/java/smmiddle/attendance/repository/StudentRepository.java
@@ -26,9 +26,9 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
           LEFT JOIN s.attendances a
             ON a.status = 'ABSENT'
            AND a.date BETWEEN :startDate AND :endDate
-          GROUP BY s.id
+          GROUP BY s.id, s.name, s.cell.name, s.cell.id
           HAVING COUNT(a) BETWEEN :minAbsence AND :maxAbsence
-          ORDER BY COUNT(a) ASC
+          ORDER BY COUNT(a) ASC, s.cell.id DESC
       """)
   Page<RankingDto> findByAbsenceCountBetween(
       @Param("startDate") LocalDate startDate,


### PR DESCRIPTION
# [변경 사항]
- 정렬 기준을 결석수로만 두었더니 무작위로 학생이 조회되어 셀id를 두 번째 정렬 기준으로 설정 
- 모든 교사가 출석부를 제출하면 오늘의 총 출석수가 계산되어야 하는데 계산 결과가 나오지 않았던 이슈 해결 (주석처리했던 것 삭제)