### PR TITLE
feat : 출석부 선택 UI 변경

### DIFF
--- a/attendance/src/main/java/smmiddle/attendance/service/StudentService.java
+++ b/attendance/src/main/java/smmiddle/attendance/service/StudentService.java
@@ -23,6 +23,7 @@ public class StudentService {
    */
   @Transactional
   public void addNewStudent(Long cellId, String newStudentName) {
+    log.info("새 친구 등록 요청: 셀 Id = {}, 이름 = {}", cellId, newStudentName);
     Cell cell = cellRepository.findById(cellId)
         .orElseThrow(() -> new ChulCheckException(ErrorCode.CELL_NOT_FOUND));
 

--- a/attendance/src/main/resources/static/css/select.css
+++ b/attendance/src/main/resources/static/css/select.css
@@ -67,23 +67,6 @@ p {
   cursor: not-allowed;
 }
 
-.scroll-down-btn {
-  position: fixed;
-  bottom: 60px;
-  right: 20px;
-  z-index: 1000;
-  background-color: rgba(50, 50, 50, 0.8); /* 회색끼 도는 투명 배경 */
-  color: white;
-  border: none;
-  border-radius: 50%;
-  width: 48px;
-  height: 48px;
-  font-size: 1.5rem;
-  cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  transition: background-color 0.3s ease;
-}
-
 /* 메시지 */
 .message {
   position: fixed;
@@ -124,35 +107,6 @@ p {
   border: 1px solid #f5c6cb;
 }
 
-/* 테이블 */
-table {
-  border-collapse: collapse;
-  width: 100%;
-  margin-top: 30px;
-  margin-bottom: 20px;
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 0 8px rgb(0 0 0 / 0.05);
-  overflow: hidden;
-}
-
-th, td {
-  padding: 12px 15px;
-  text-align: center;
-  font-size: 1.125rem;
-  border-bottom: 1px solid #eee;
-}
-
-th {
-  background-color: #f4f6f8;
-  font-weight: 700;
-  color: #4a4a4a;
-}
-
-tr:last-child td {
-  border-bottom: none;
-}
-
 .status-submitted {
   color: #2e7d32;
   font-weight: 700;
@@ -165,7 +119,42 @@ tr:last-child td {
   font-size: 1.2em;
 }
 
-/*.records-btn-container {*/
-/*  text-align: center;*/
-/*  margin-top: 40px;*/
-/*}*/
+.cell-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 15px;
+  margin: 20px 0;
+}
+
+.cell-grid-item {
+  text-align: center;
+}
+
+.cell-grid-item button {
+  width: 100%;
+  padding: 15px 10px;
+  background-color: white;
+  border: 2px solid #ccc;
+  border-radius: 10px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #333;
+}
+
+.cell-grid-item.submitted button {
+  border-color: #2e7d32;
+  background-color: #e8f5e9;
+  color: #2e7d32;
+}
+
+/* 기본 회색 버튼 */
+.cell-grid-item.pending button {
+  border-color: #ccc;
+  background-color: #f8f8f8;
+  color: #666;
+}

--- a/attendance/src/main/resources/static/js/select.js
+++ b/attendance/src/main/resources/static/js/select.js
@@ -1,6 +1,3 @@
-document.getElementById("scrollToBottomBtn").addEventListener("click", () => {
-  window.scrollTo({top: document.body.scrollHeight, behavior: 'smooth'});
-});
 
 document.addEventListener('DOMContentLoaded', () => {
   const messages = document.querySelectorAll(

--- a/attendance/src/main/resources/templates/select_cell.html
+++ b/attendance/src/main/resources/templates/select_cell.html
@@ -12,8 +12,6 @@
 </head>
 <body>
 
-<button id="scrollToBottomBtn" class="scroll-down-btn">⬇</button>
-
 <div style="position: relative;">
   <h1>🏠 출석부</h1>
   <p th:if="${!isSunday}" class="warning-card">
@@ -31,39 +29,56 @@
   </p>
 </div>
 
+<div class="cell-grid">
+  <form th:each="cell : ${cells}"
+        th:action="${attendanceStatusMap[cell.id]} ? @{/attendance/edit} : @{/attendance/form}"
+        method="get"
+        class="cell-grid-item"
+        th:classappend="${attendanceStatusMap[cell.id]} ? 'submitted' : 'pending'">
+    <input type="hidden" name="cellId" th:value="${cell.id}"/>
+    <button type="submit" th:disabled="${!isSunday}">
+      <span>
+        <span th:text="${cell.name}"></span>
+        <span th:if="${attendanceStatusMap[cell.id]}" style="margin-left: 4px;">✅</span>
+      </span>
+    </button>
+  </form>
+</div>
+
 <!-- 메시지 -->
 <div th:if="${success}" class="message message-success" th:text="${success}"></div>
 <div th:if="${error}" class="message message-error" th:text="${error}"></div>
 
-<!-- 셀 테이블 -->
-<table>
-  <thead>
-  <tr>
-    <th>셀</th>
-    <th>교사</th>
-    <th>제출 여부</th>
-    <th></th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr th:each="cell : ${cells}">
-    <td th:text="${cell.name}">셀 이름</td>
-    <td th:text="${cell.teacher}">교사 이름</td>
-    <td th:text="${attendanceStatusMap[cell.id] ? '✅' : '❌'}"
-        th:classappend="${attendanceStatusMap[cell.id]} ? 'status-submitted' : 'status-pending'"></td>
-    <td>
-      <form th:if="${!attendanceStatusMap[cell.id]}" th:action="@{/attendance/form}" method="get">
-        <input type="hidden" name="cellId" th:value="${cell.id}"/>
-        <button type="submit" class="btn btn-submit" th:disabled="${!isSunday}">출석</button>
-      </form>
-      <form th:if="${attendanceStatusMap[cell.id]}" th:action="@{/attendance/edit}" method="get">
-        <input type="hidden" name="cellId" th:value="${cell.id}"/>
-        <button type="submit" class="btn btn-edit" th:disabled="${!isSunday}">수정</button>
-      </form>
-    </td>
-  </tr>
-  </tbody>
-</table>
+<!--&lt;!&ndash; 셀 테이블 &ndash;&gt;-->
+<!--<table>-->
+<!--  <thead>-->
+<!--  <tr>-->
+<!--    <th>셀</th>-->
+<!--    <th>교사</th>-->
+<!--    <th>제출 여부</th>-->
+<!--    <th></th>-->
+<!--  </tr>-->
+<!--  </thead>-->
+<!--  <tbody>-->
+<!--  <tr th:each="cell : ${cells}">-->
+<!--    <td th:text="${cell.name}">셀 이름</td>-->
+<!--    <td th:text="${cell.teacher}">교사 이름</td>-->
+<!--    <td th:text="${attendanceStatusMap[cell.id] ? '✅' : '❌'}"-->
+<!--        th:classappend="${attendanceStatusMap[cell.id]} ? 'status-submitted' : 'status-pending'"></td>-->
+<!--    <td>-->
+<!--      <form th:if="${!attendanceStatusMap[cell.id]}" th:action="@{/attendance/form}" method="get">-->
+<!--        <input type="hidden" name="cellId" th:value="${cell.id}"/>-->
+<!--        <button type="submit" class="btn btn-submit" th:disabled="${!isSunday}">출석</button>-->
+<!--      </form>-->
+<!--      <form th:if="${attendanceStatusMap[cell.id]}" th:action="@{/attendance/edit}" method="get">-->
+<!--        <input type="hidden" name="cellId" th:value="${cell.id}"/>-->
+<!--        <button type="submit" class="btn btn-edit" th:disabled="${!isSunday}">수정</button>-->
+<!--      </form>-->
+<!--    </td>-->
+<!--  </tr>-->
+<!--  </tbody>-->
+<!--</table>-->
+
 
 <!-- 최근 수정시간 -->
 <div th:if="${lastUpdatedTime != null and isSunday}" style="text-align: center; margin-top: 10px;">
@@ -73,13 +88,6 @@
     (<span th:text="${lastUpdatedCellName}"></span>)
   </p>
 </div>
-
-<!-- 출결 내역 버튼 -->
-<!--<div class="records-btn-container">-->
-<!--  <form th:action="@{/attendance/records}" method="get">-->
-<!--    <button type="submit" class="btn btn-submit">📋 셀별 출결 내역</button>-->
-<!--  </form>-->
-<!--</div>-->
 
 <!-- 예외 모달 -->
 <div id="errorModal" style="display: none; position: fixed; top: 0; left: 0;


### PR DESCRIPTION
# [변경 사항]

- 반별 출석 상태를 기존 테이블 대신 한눈에 보기 쉽게 그리드 UI로 변경
- 제출 : 초록색 테두리 강조와 ✅ 아이콘 표시
- 미제출 : 회색 테두리 처리
- 각 반 버튼 클릭 시 출석 제출/수정 폼으로 이동 (기존 기능 유지)
- 스크롤다운 버튼 삭제 