### PR TITLE
feat : 출결내역 조회 방식 변경

### DIFF
--- a/attendance/src/main/java/smmiddle/attendance/dto/RecordDto.java
+++ b/attendance/src/main/java/smmiddle/attendance/dto/RecordDto.java
@@ -1,0 +1,14 @@
+package smmiddle.attendance.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import smmiddle.attendance.entity.Attendance;
+
+@Getter
+@AllArgsConstructor
+public class RecordDto {
+  private List<Attendance> attendanceList;
+  private long presentCount;
+
+}

--- a/attendance/src/main/resources/static/css/record.css
+++ b/attendance/src/main/resources/static/css/record.css
@@ -135,29 +135,60 @@ th {
   padding: 0;
 }
 
-
-/*.back-button {*/
-/*  margin-top: 40px;*/
-/*  text-align: center;*/
-/*}*/
-
-/*.back-button button {*/
-/*  background-color: #95a5a6;*/
-/*  color: white;*/
-/*  padding: 10px 24px;*/
-/*  border: none;*/
-/*  border-radius: 8px;*/
-/*  font-weight: bold;*/
-/*  cursor: pointer;*/
-/*}*/
-
-/*.back-button button:hover {*/
-/*  background-color: #7f8c8d;*/
-/*}*/
-
 @media (min-width: 768px) {
   .filter-section {
     flex-direction: row;
     align-items: center;
   }
+}
+
+.card-container {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch; /* iOS 터치 부드럽게 */
+  gap: 15px;
+  padding: 10px 0;
+}
+
+.card-wrapper {
+  display: inline-block;
+  vertical-align: top;
+  width: 320px;
+  margin-right: 15px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 0 6px rgba(0,0,0,0.1);
+  padding: 15px;
+  scroll-snap-align: start;
+  flex: 0 0 320px; /* 카드 너비 고정 */
+}
+
+
+@media (min-width: 600px) {
+  .card-wrapper {
+    flex: 0 0 45%;
+    width: 45%;
+  }
+}
+
+@media (min-width: 900px) {
+  .card-wrapper {
+    flex: 0 0 30%;
+    width: 30%;
+  }
+}
+
+@media (min-width: 1200px) {
+  .card-wrapper {
+    flex: 0 0 22%;
+    width: 22%;
+  }
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 1.3rem;
+  color: #3f51b5;
 }

--- a/attendance/src/main/resources/templates/attendance_records.html
+++ b/attendance/src/main/resources/templates/attendance_records.html
@@ -2,8 +2,8 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="robots" content="noindex, nofollow">
 
   <title>출석 내역 조회</title>
@@ -13,32 +13,29 @@
 </head>
 
 <body>
+
 <h1>
   <a th:href="@{/attendance/records}">💾 출석 내역 조회</a>
 </h1>
 
 <form th:action="@{/attendance/records}" method="get" class="filter-section">
-  <label for="cellId">셀 :</label>
-  <select name="cellId" id="cellId" required>
-    <option value="0" th:text="'셀을 선택하세요'"></option>
-    <option th:each="cell : ${cells}" th:value="${cell.id}" th:text="${cell.name}"></option>
-  </select>
-
   <label for="date">날짜 :</label>
-  <select name="date" id="date" required>
+  <select name="date" id="date" required onchange="this.form.submit()">
     <option value="" disabled selected>날짜를 선택하세요</option>
-    <option th:each="date : ${dates}" th:value="${#temporals.format(date, 'yyyy-MM-dd')}" th:text="${#temporals.format(date, 'yyyy-MM-dd')}"></option>
+    <option th:each="date : ${dates}" th:value="${#temporals.format(date, 'yyyy-MM-dd')}"
+            th:text="${#temporals.format(date, 'yyyy-MM-dd')}"
+            th:selected="${selectedDate == #temporals.format(date, 'yyyy-MM-dd')}"></option>
   </select>
-
-  <button type="submit">조회</button>
 </form>
 
-<hr />
+<hr/>
 
 <div th:if="${summaryList != null} and ${attendances} == null">
   <div class="summary-header">
     <h3 style="margin: 0;">📢 오늘의 출석 요약</h3>
-    <button class="scroll-button" onclick="window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });" aria-label="맨 아래로 스크롤">⬇</button>
+    <button class="scroll-button"
+            onclick="window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });">⬇
+    </button>
   </div>
   <table>
     <thead>
@@ -56,51 +53,49 @@
   </table>
 </div>
 
-<div th:if="${attendances != null}">
-  <h2 th:text="${selectedCellName}"></h2>
-  <h3 th:text="'날짜: ' + ${selectedDate}"></h3>
-
-  <table>
-    <thead>
-    <tr>
-      <th>이름</th>
-      <th>출결</th>
-      <th>결석 사유</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr th:if="${#lists.isEmpty(attendances)}">
-      <td colspan="3" style="font-style: italic;">아직 출석 정보가 없습니다.</td>
-    </tr>
-    <tr th:each="att : ${attendances}">
-      <td th:text="${att.student.name}"></td>
-      <td>
-        <span th:if="${att.status.name() == 'PRESENT' or att.status.name() == 'ALLOWED'}" class="present">✅</span>
-        <span th:if="${att.status.name() == 'ABSENT' and (att.absenceReason.name() != 'NAVE' and att.absenceReason.name() != 'OTHER_CHURCH')}" class="absent">❌</span>
-      </td>
-      <td>
-            <span th:if="${att.status == T(smmiddle.attendance.constant.AttendanceStatus).ABSENT}">
-              <span th:text="${att.absenceReason != null ? att.absenceReason.displayName : ''}"></span>
-              <span th:if="${att.absenceReason == T(smmiddle.attendance.constant.AbsenceReason).OTHER and att.customReason != null}">: <span th:text="${att.customReason}"></span></span>
-            </span>
-        <span th:if="${att.status == T(smmiddle.attendance.constant.AttendanceStatus).PRESENT}">-</span>
-      </td>
-    </tr>
-    </tbody>
-    <tfoot th:if="${not #lists.isEmpty(attendances)}">
-    <tr>
-      <td><strong>총계</strong></td>
-      <td colspan="2"><strong th:text="'출석: ' + ${presentCount}"></strong></td>
-    </tr>
-    </tfoot>
-  </table>
+<div th:if="${cellAttendanceMap != null}">
+  <div class="card-container">
+    <div class="card-wrapper" th:each="entry : ${cellAttendanceMap}">
+      <div class="card">
+        <h3 th:text="${entry.key.name + ' (출석 : ' + entry.value.presentCount + '명)'}"></h3>
+        <table>
+          <thead>
+          <tr>
+            <th>이름</th>
+            <th>출결</th>
+            <th>결석 사유</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:if="${#lists.isEmpty(entry.value.attendanceList)}">
+            <td colspan="3" style="font-style: italic;">아직 출석 정보가 없습니다.</td>
+          </tr>
+          <tr th:each="att : ${entry.value.attendanceList}">
+            <td th:text="${att.student.name}"></td>
+            <td>
+              <span th:if="${att.status.name() == 'PRESENT' or att.status.name() == 'ALLOWED'}"
+                    class="present">✅</span>
+              <span th:if="${att.status.name() == 'ABSENT'}" class="absent">❌</span>
+            </td>
+            <td>
+                <span
+                    th:if="${att.status == T(smmiddle.attendance.constant.AttendanceStatus).ABSENT || att.status == T(smmiddle.attendance.constant.AttendanceStatus).ALLOWED}">
+                  <span
+                      th:text="${att.absenceReason != null ? att.absenceReason.displayName : ''}"></span>
+                  <span
+                      th:if="${att.absenceReason == T(smmiddle.attendance.constant.AbsenceReason).OTHER and att.customReason != null}">: <span
+                      th:text="${att.customReason}"></span></span>
+                </span>
+              <span
+                  th:if="${att.status == T(smmiddle.attendance.constant.AttendanceStatus).PRESENT}">-</span>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
 </div>
-
-<!--<div class="back-button">-->
-<!--  <form th:action="@{/}" method="get">-->
-<!--    <button type="submit">🏠 첫 화면으로 돌아가기</button>-->
-<!--  </form>-->
-<!--</div>-->
 
 <div th:replace="~{nav :: bottom-nav}"></div>
 


### PR DESCRIPTION
# [변경 사항]
- 셀 - 날짜 순으로 선택하는 것이 번거롭게 느껴져 날짜만 선택하는 방법으로 변경. 
- 해당 날짜의 모든 셀 출결 사항을 불러온 후, 옆으로 스와이프하며 각 셀의 출결 사항을 볼 수 있도록 수정
- 화면 비율에 따라 한 번에 조회되는 카드 수 상이 