### PR TITLE
refactor : 제출-수정 플로우가 아니라 제출-제출 되는 이슈 해결 외 리팩토링

### DIFF
--- a/attendance/src/main/java/smmiddle/attendance/controller/AttendanceController.java
+++ b/attendance/src/main/java/smmiddle/attendance/controller/AttendanceController.java
@@ -3,7 +3,6 @@ package smmiddle.attendance.controller;
 import static smmiddle.attendance.component.SessionUtil.isNotAuthenticated;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -80,26 +79,17 @@ public class AttendanceController {
   public String showAttendanceForm(
       HttpSession session,
       @RequestParam Long cellId,
-      Model model,
-      RedirectAttributes redirectAttributes,
-      HttpServletResponse response) {
+      Model model) {
 
     if (isNotAuthenticated(session)) {
       log.warn("비인증 사용자가 접근 시도");
       return "redirect:/auth";  // 인증 안 됐으면 인증 페이지로 보내기
     }
 
-    // 캐시 방지 헤더
-    response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-    response.setHeader("Pragma", "no-cache");
-    response.setDateHeader("Expires", 0);
-
     LocalDate today = LocalDate.now();
-
-    boolean submitted = attendanceService.alreadySubmitted(cellId, today);
-    if (submitted) {
-      redirectAttributes.addFlashAttribute("warning", "⚠️ 이미 제출되었습니다.");
-      return "redirect:/";  // 셀 선택 페이지로 돌아가기
+    if (attendanceService.alreadySubmitted(cellId, today)) {
+      log.info("이미 제출된 셀 [{}]의 출석부. 수정 화면으로 이동", cellId);
+      return "redirect:/attendance/edit?cellId=" + cellId;
     }
 
     model.addAttribute("formDto", buildFormViewDto(cellId, false));

--- a/attendance/src/main/java/smmiddle/attendance/controller/AttendanceController.java
+++ b/attendance/src/main/java/smmiddle/attendance/controller/AttendanceController.java
@@ -3,6 +3,7 @@ package smmiddle.attendance.controller;
 import static smmiddle.attendance.component.SessionUtil.isNotAuthenticated;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -78,12 +79,29 @@ public class AttendanceController {
   @GetMapping("/attendance/form")
   public String showAttendanceForm(
       HttpSession session,
-      @RequestParam Long cellId, Model model) {
+      @RequestParam Long cellId,
+      Model model,
+      RedirectAttributes redirectAttributes,
+      HttpServletResponse response) {
 
     if (isNotAuthenticated(session)) {
       log.warn("비인증 사용자가 접근 시도");
       return "redirect:/auth";  // 인증 안 됐으면 인증 페이지로 보내기
     }
+
+    // 캐시 방지 헤더
+    response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    response.setHeader("Pragma", "no-cache");
+    response.setDateHeader("Expires", 0);
+
+    LocalDate today = LocalDate.now();
+
+    boolean submitted = attendanceService.alreadySubmitted(cellId, today);
+    if (submitted) {
+      redirectAttributes.addFlashAttribute("warning", "⚠️ 이미 제출되었습니다.");
+      return "redirect:/";  // 셀 선택 페이지로 돌아가기
+    }
+
     model.addAttribute("formDto", buildFormViewDto(cellId, false));
     return "attendance_form";
   }

--- a/attendance/src/main/resources/static/css/form.css
+++ b/attendance/src/main/resources/static/css/form.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  margin: 30px 30px 80px;
+  margin: 30px;
   background: #fafafa;
   color: #333;
 }
@@ -17,6 +17,10 @@ h1 {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 20px;
+}
+
+.cell-info {
+  margin-bottom: 10px;
 }
 
 .add-btn {
@@ -83,11 +87,10 @@ input[type="radio"] {
   font-size: 1rem;
   cursor: pointer;
   transition: border-color 0.3s, color 0.3s;
-  user-select: none;
-  display: inline-block;
+  /*user-select: none;*/
+  /*display: inline-block;*/
   text-align: center;
   min-width: 50px;
-  background-color: transparent;
 }
 
 .attendance-buttons input[type="radio"]:checked + label.present-label {
@@ -99,18 +102,6 @@ input[type="radio"] {
 
 .attendance-buttons input[type="radio"]:checked + label.absent-label {
   background-color: #ffebee;
-  color: #7f2a2a !important;
-  border-color: #f44336 !important;
-  font-weight: 700;
-}
-
-.attendance-buttons input[type="radio"]:checked + label.present-label {
-  color: #1b4d1b !important;
-  border-color: #4caf50 !important;
-  font-weight: 700;
-}
-
-.attendance-buttons input[type="radio"]:checked + label.absent-label {
   color: #7f2a2a !important;
   border-color: #f44336 !important;
   font-weight: 700;
@@ -131,7 +122,11 @@ input[type="radio"] {
   border: 1px solid #ccc;
   border-radius: 6px;
   font-size: 1rem;
-  box-sizing: border-box;
+  /*box-sizing: border-box;*/
+}
+
+.custom-reason-input {
+  display: none;
 }
 
 button[type="submit"] {
@@ -151,7 +146,7 @@ button[type="submit"] {
 
 @media (max-width: 480px) {
   .student-card {
-    padding: 12px 12px;
+    padding: 12px;
   }
 
   .student-name {
@@ -166,7 +161,7 @@ button[type="submit"] {
   }
 }
 
-#studentModal {
+.modal {
   display: none;
   position: fixed;
   z-index: 999;
@@ -218,7 +213,6 @@ button[type="submit"] {
   border-radius: 6px;
   font-weight: bold;
   cursor: pointer;
-  font-size: 1rem;
 }
 
 /* 토스트 스타일 */

--- a/attendance/src/main/resources/static/css/form.css
+++ b/attendance/src/main/resources/static/css/form.css
@@ -122,7 +122,7 @@ input[type="radio"] {
   border: 1px solid #ccc;
   border-radius: 6px;
   font-size: 1rem;
-  /*box-sizing: border-box;*/
+  box-sizing: border-box;
 }
 
 .custom-reason-input {

--- a/attendance/src/main/resources/static/css/nav.css
+++ b/attendance/src/main/resources/static/css/nav.css
@@ -34,3 +34,7 @@
   font-size: 10px;
   margin-top: 2px;
 }
+
+.active-nav span:first-child {
+  filter: drop-shadow(0 0 3px black);
+}

--- a/attendance/src/main/resources/static/css/rank.css
+++ b/attendance/src/main/resources/static/css/rank.css
@@ -82,10 +82,6 @@ th:nth-child(3), td:nth-child(3) {
   width: 25%;
 }
 
-.active-nav span:first-child {
-  filter: drop-shadow(0 0 3px black);
-}
-
 .pagination {
   margin-top: 20px;
   text-align: center;

--- a/attendance/src/main/resources/static/css/record.css
+++ b/attendance/src/main/resources/static/css/record.css
@@ -63,10 +63,6 @@ button[type="submit"] {
   padding: 10px 20px;
 }
 
-button[type="submit"]:hover {
-  background-color: var(--hover);
-}
-
 hr {
   border: none;
   border-top: 1px solid #ddd;
@@ -107,11 +103,18 @@ th {
   font-size: 1.1rem;
 }
 
+.no-attendance {
+  font-style: italic;
+}
+
 .summary-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 10px;
+}
+.summary-header h3 {
+  margin: 0;
 }
 
 .scroll-button {
@@ -142,7 +145,7 @@ th {
   display: flex;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
-  -webkit-overflow-scrolling: touch; /* iOS 터치 부드럽게 */
+  -webkit-overflow-scrolling: touch;
   gap: 15px;
   padding: 10px 0;
 }

--- a/attendance/src/main/resources/static/css/record.css
+++ b/attendance/src/main/resources/static/css/record.css
@@ -15,7 +15,7 @@
 
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  margin: 30px 30px 80px;
+  margin: 20px 30px 80px;
   background-color: #fafafa;
   color: #333;
 }
@@ -25,7 +25,19 @@ h1, h2, h3 {
   color: #2c3e50;
 }
 
-h1 a {
+.title-container {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.title-container h1 {
+  color: #2c3e50;
+  padding-bottom: 8px;
+  border-bottom: 3px solid #2c3e50;
+  display: inline-block;
+}
+
+.title-container h1 a {
   text-decoration: none;
   color: inherit;
 }
@@ -38,13 +50,7 @@ h1 a {
   margin-bottom: 30px;
 }
 
-label {
-  font-weight: 600;
-  color: var(--muted);
-}
-
-select,
-button {
+.form-control {
   font-size: 1rem;
   padding: 8px 12px;
   border-radius: 8px;
@@ -153,36 +159,12 @@ th {
 .card-wrapper {
   display: inline-block;
   vertical-align: top;
-  width: 320px;
-  margin-right: 15px;
-  background-color: white;
+  background-color: #f0f0f0;
   border-radius: 8px;
   box-shadow: 0 0 6px rgba(0,0,0,0.1);
   padding: 15px;
   scroll-snap-align: start;
-  flex: 0 0 320px; /* 카드 너비 고정 */
-}
-
-
-@media (min-width: 600px) {
-  .card-wrapper {
-    flex: 0 0 45%;
-    width: 45%;
-  }
-}
-
-@media (min-width: 900px) {
-  .card-wrapper {
-    flex: 0 0 30%;
-    width: 30%;
-  }
-}
-
-@media (min-width: 1200px) {
-  .card-wrapper {
-    flex: 0 0 22%;
-    width: 22%;
-  }
+  flex: 0 0 320px;
 }
 
 .card h3 {
@@ -191,3 +173,25 @@ th {
   font-size: 1.3rem;
   color: #3f51b5;
 }
+
+@media (min-width: 600px) {
+  .card-wrapper {
+    flex: 0 0 45%;
+    /*width: 45%;*/
+  }
+}
+
+@media (min-width: 900px) {
+  .card-wrapper {
+    flex: 0 0 30%;
+    /*width: 30%;*/
+  }
+}
+
+@media (min-width: 1200px) {
+  .card-wrapper {
+    flex: 0 0 22%;
+    /*width: 22%;*/
+  }
+}
+

--- a/attendance/src/main/resources/static/css/record.css
+++ b/attendance/src/main/resources/static/css/record.css
@@ -30,10 +30,6 @@ h1 a {
   color: inherit;
 }
 
-.active-nav span:first-child {
-  filter: drop-shadow(0 0 3px black);
-}
-
 .filter-section {
   display: flex;
   flex-direction: column;

--- a/attendance/src/main/resources/static/css/select.css
+++ b/attendance/src/main/resources/static/css/select.css
@@ -107,18 +107,6 @@ p {
   border: 1px solid #f5c6cb;
 }
 
-.status-submitted {
-  color: #2e7d32;
-  font-weight: 700;
-  font-size: 1.2rem;
-}
-
-.status-pending {
-  color: #c62828;
-  font-weight: 700;
-  font-size: 1.2em;
-}
-
 .cell-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));

--- a/attendance/src/main/resources/static/css/select.css
+++ b/attendance/src/main/resources/static/css/select.css
@@ -10,7 +10,10 @@ body {
 h1 {
   text-align: center;
   color: #2c3e50;
-  margin-bottom: 30px;
+  margin-bottom: 15px;
+  padding-bottom: 8px;
+  border-bottom: 3px solid #2c3e50;
+  display: inline-block;
 }
 
 p {

--- a/attendance/src/main/resources/static/css/select.css
+++ b/attendance/src/main/resources/static/css/select.css
@@ -20,11 +20,8 @@ p {
   color: #555;
 }
 
-.active-nav span:first-child {
-  filter: drop-shadow(0 0 3px black);
-}
-
-.warning-card {
+/* 요일 제한 */
+.not-sunday {
   background-color: #fff4f4;
   border: 2px solid orangered;
   border-radius: 10px;

--- a/attendance/src/main/resources/static/css/select.css
+++ b/attendance/src/main/resources/static/css/select.css
@@ -74,7 +74,7 @@ p {
   left: 50%;
   transform: translateX(-50%);
   z-index: 9999;
-  padding: 33px 40px;
+  padding: 35px 40px;
   border-radius: 8px;
   font-weight: 500;
   font-size: 1.2rem;
@@ -101,7 +101,7 @@ p {
   border: 1px solid #a2e1db;
 }
 
-.message-error {
+.message-error, .exception-error {
   background-color: #f8d7da;
   color: #721c24;
   border: 1px solid #f5c6cb;

--- a/attendance/src/main/resources/static/css/select.css
+++ b/attendance/src/main/resources/static/css/select.css
@@ -2,24 +2,32 @@ body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #fafafa;
   color: #333;
-  margin: 30px auto  80px;
+  margin: 20px auto  80px;
   max-width: 900px;
   padding: 0 20px;
 }
 
-h1 {
+.title-container {
   text-align: center;
+  margin-bottom: 10px;
+}
+
+.title-container h1 {
   color: #2c3e50;
-  margin-bottom: 15px;
   padding-bottom: 8px;
   border-bottom: 3px solid #2c3e50;
   display: inline-block;
 }
 
+.title-container h1 a {
+  text-decoration: none;
+  color: inherit;
+}
+
 p {
   text-align: center;
   font-size: 1rem;
-  margin-top: 5px;
+  margin-top: 1px;
   color: #555;
 }
 

--- a/attendance/src/main/resources/static/js/select.js
+++ b/attendance/src/main/resources/static/js/select.js
@@ -1,7 +1,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const messages = document.querySelectorAll(
-      '.message-success, .message-error');
+      '.message-success, .message-error, .exception-error');
   messages.forEach((msg) => {
     setTimeout(() => {
       msg.style.opacity = '0';
@@ -12,17 +12,3 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 2000);
   });
 });
-
-function showModal(message) {
-  document.getElementById('modalErrorMessage').textContent = message;
-  document.getElementById('errorModal').style.display = 'flex';
-}
-
-function closeModal() {
-  window.location.href = "/";
-}
-
-const errorMessage = /*[[${chulcheckErrorMessage}]]*/ null;
-if (errorMessage) {
-  showModal(errorMessage);
-}

--- a/attendance/src/main/resources/templates/attendance_form.html
+++ b/attendance/src/main/resources/templates/attendance_form.html
@@ -15,12 +15,12 @@
   <button class="add-btn" type="button" onclick="openStudentModal()">➕ 새 친구</button>
 </div>
 
-<div style="margin-bottom: 10px;">
+<section class="cell-info">
   <p><strong>담당 셀 :</strong> <span th:text="${formDto.cell.name}"></span></p>
-  <p><strong>담당 교사:</strong> <span th:text="${formDto.cell.teacher}"></span></p>
-  <p><strong>출석 날짜:</strong> <span th:text="${#temporals.format(formDto.today, 'yyyy-MM-dd')}"></span></p>
-</div>
-
+  <p><strong>담당 교사 :</strong> <span th:text="${formDto.cell.teacher}"></span></p>
+  <p><strong>출석 날짜 :</strong> <span
+      th:text="${#temporals.format(formDto.today, 'yyyy-MM-dd')}"></span></p>
+</section>
 <div class="section-divider"></div>
 
 <form th:action="@{/attendance/submit}" method="post">
@@ -33,45 +33,47 @@
 
       <div class="attendance-buttons">
         <input type="radio"
-               th:id="'present_' + ${student.id}"
-               th:name="'status_' + ${student.id}"
-               th:value="'PRESENT'"
+               th:id="|present_${student.id}|"
+               th:name="|status_${student.id}|"
+               value="PRESENT"
                class="present"
-               th:checked="${formDto.attendanceMap == null or formDto.attendanceMap[student.id] == null or formDto.attendanceMap[student.id]?.status?.name() == 'PRESENT'}"
-               th:onclick="'toggleReasonInput(' + ${student.id} + ')'"/>
+               th:checked="${formDto.attendanceMap == null
+                            or formDto.attendanceMap[student.id] == null
+                            or formDto.attendanceMap[student.id]?.status?.name() == 'PRESENT'}"
+               th:onclick="|toggleReasonInput(${student.id})|"/>
         <label th:for="'present_' + ${student.id}" class="present-label">출석</label>
 
         <input type="radio"
-               th:id="'absent_' + ${student.id}"
-               th:name="'status_' + ${student.id}"
-               th:value="'ABSENT'"
+               th:id="|absent_${student.id}|"
+               th:name="|status_${student.id}|"
+               value="ABSENT"
                class="absent"
-               th:checked="${formDto.attendanceMap != null and (formDto.attendanceMap[student.id]?.status?.name() == 'ABSENT' or formDto.attendanceMap[student.id]?.status?.name() == 'ALLOWED')}"
-               th:onclick="'toggleReasonInput(' + ${student.id} + ')'"/>
-        <label th:for="'absent_' + ${student.id}" class="absent-label">결석</label>
+               th:checked="${formDto.attendanceMap != null
+                            and (formDto.attendanceMap[student.id]?.status?.name() == 'ABSENT'
+                                 or formDto.attendanceMap[student.id]?.status?.name() == 'ALLOWED')}"
+               th:onclick="|toggleReasonInput(${student.id})|"/>
+        <label th:for="|absent_${student.id}|" class="absent-label">결석</label>
       </div>
 
-      <div class="reason-section" th:id="'reasonSection_' + ${student.id}">
-        <select
-            th:name="'absenceReason_' + ${student.id}"
-            th:id="'reasonSelect_' + ${student.id}"
-            th:onchange="'toggleCustomReason(' + ${student.id} + ')'"
-            required>
+      <div class="reason-section" th:id="|reasonSection_${student.id}|">
+        <select th:name="|absenceReason_${student.id}|"
+                th:id="|reasonSelect_${student.id}|"
+                th:onchange="|toggleCustomReason(${student.id})|"
+                required>
           <option value="" disabled selected>선택</option>
-          <option
-              th:each="reason : ${formDto.absenceReasons}"
-              th:value="${reason.name()}"
-              th:selected="${formDto.attendanceMap[student.id]?.absenceReason?.name() == reason.name()}"
-              th:text="${reason.displayName}"
-          >사유</option>
+          <option th:each="reason : ${formDto.absenceReasons}"
+                  th:value="${reason.name()}"
+                  th:selected="${formDto.attendanceMap[student.id]?.absenceReason?.name() == reason.name()}"
+                  th:text="${reason.displayName}">
+          </option>
         </select>
 
         <input type="text"
-               th:name="'customReason_' + ${student.id}"
-               th:id="'customReason_' + ${student.id}"
+               th:name="|customReason_${student.id}|"
+               th:id="|customReason_${student.id}|"
                th:value="${formDto.attendanceMap[student.id]?.customReason}"
                placeholder="기타 사유 입력"
-               style="display:none;"/>
+               class="custom-reason-input"/>
       </div>
     </div>
   </div>
@@ -80,15 +82,13 @@
 
 </form>
 <!--친구추가 모달-->
-<div id="studentModal" style="display:none;">
+<div id="studentModal" class="modal">
   <div class="modal-content">
-    <!-- 오른쪽 상단 X 버튼 -->
     <button class="close-btn" onclick="closeStudentModal()" aria-label="닫기">&times;</button>
-    <h2 style="margin-top: 0;">새 친구 등록</h2>
+    <h2>새 친구 등록</h2>
     <form id="addStudentForm">
       <input type="hidden" name="cellId" th:value="${formDto.cell.id}"/>
-      <input type="text" name="studentName" placeholder="이름" required
-             style="margin-top: 10px; margin-bottom: 2px;"/>
+      <input type="text" name="studentName" placeholder="이름" required/>
       <div class="modal-buttons">
         <button type="submit" class="submit-btn">등록</button>
         <p>⚠️ 새 친구를 등록하면 화면이 새로고침되어<br/>기존에 체크했던 출결사항이<br/>초기화될 수 있습니다.</p>

--- a/attendance/src/main/resources/templates/attendance_form.html
+++ b/attendance/src/main/resources/templates/attendance_form.html
@@ -78,7 +78,7 @@
     </div>
   </div>
 
-  <button type="submit">출결사항 제출</button>
+  <button type="submit" th:text="${formDto.isEdit} ? '출결사항 수정' : '출결사항 제출'"></button>
 
 </form>
 <!--친구추가 모달-->

--- a/attendance/src/main/resources/templates/attendance_form.html
+++ b/attendance/src/main/resources/templates/attendance_form.html
@@ -32,26 +32,22 @@
       <div class="student-name" th:text="${student.name}">학생 이름</div>
 
       <div class="attendance-buttons">
-        <input
-            type="radio"
-            th:id="'present_' + ${student.id}"
-            th:name="'status_' + ${student.id}"
-            th:value="'PRESENT'"
-            class="present"
-            th:checked="${formDto.attendanceMap == null or formDto.attendanceMap[student.id] == null or formDto.attendanceMap[student.id]?.status?.name() == 'PRESENT'}"
-            th:onclick="'toggleReasonInput(' + ${student.id} + ')'"
-        />
+        <input type="radio"
+               th:id="'present_' + ${student.id}"
+               th:name="'status_' + ${student.id}"
+               th:value="'PRESENT'"
+               class="present"
+               th:checked="${formDto.attendanceMap == null or formDto.attendanceMap[student.id] == null or formDto.attendanceMap[student.id]?.status?.name() == 'PRESENT'}"
+               th:onclick="'toggleReasonInput(' + ${student.id} + ')'"/>
         <label th:for="'present_' + ${student.id}" class="present-label">출석</label>
 
-        <input
-            type="radio"
-            th:id="'absent_' + ${student.id}"
-            th:name="'status_' + ${student.id}"
-            th:value="'ABSENT'"
-            class="absent"
-            th:checked="${formDto.attendanceMap != null and (formDto.attendanceMap[student.id]?.status?.name() == 'ABSENT' or formDto.attendanceMap[student.id]?.status?.name() == 'ALLOWED')}"
-            th:onclick="'toggleReasonInput(' + ${student.id} + ')'"
-        />
+        <input type="radio"
+               th:id="'absent_' + ${student.id}"
+               th:name="'status_' + ${student.id}"
+               th:value="'ABSENT'"
+               class="absent"
+               th:checked="${formDto.attendanceMap != null and (formDto.attendanceMap[student.id]?.status?.name() == 'ABSENT' or formDto.attendanceMap[student.id]?.status?.name() == 'ALLOWED')}"
+               th:onclick="'toggleReasonInput(' + ${student.id} + ')'"/>
         <label th:for="'absent_' + ${student.id}" class="absent-label">결석</label>
       </div>
 
@@ -60,27 +56,22 @@
             th:name="'absenceReason_' + ${student.id}"
             th:id="'reasonSelect_' + ${student.id}"
             th:onchange="'toggleCustomReason(' + ${student.id} + ')'"
-            required
-        >
+            required>
           <option value="" disabled selected>선택</option>
           <option
               th:each="reason : ${formDto.absenceReasons}"
               th:value="${reason.name()}"
               th:selected="${formDto.attendanceMap[student.id]?.absenceReason?.name() == reason.name()}"
               th:text="${reason.displayName}"
-          >
-            사유
-          </option>
+          >사유</option>
         </select>
 
-        <input
-            type="text"
-            th:name="'customReason_' + ${student.id}"
-            th:id="'customReason_' + ${student.id}"
-            th:value="${formDto.attendanceMap[student.id]?.customReason}"
-            placeholder="기타 사유 입력"
-            style="display:none;"
-        />
+        <input type="text"
+               th:name="'customReason_' + ${student.id}"
+               th:id="'customReason_' + ${student.id}"
+               th:value="${formDto.attendanceMap[student.id]?.customReason}"
+               placeholder="기타 사유 입력"
+               style="display:none;"/>
       </div>
     </div>
   </div>
@@ -88,11 +79,11 @@
   <button type="submit">출결사항 제출</button>
 
 </form>
+<!--친구추가 모달-->
 <div id="studentModal" style="display:none;">
   <div class="modal-content">
     <!-- 오른쪽 상단 X 버튼 -->
     <button class="close-btn" onclick="closeStudentModal()" aria-label="닫기">&times;</button>
-
     <h2 style="margin-top: 0;">새 친구 등록</h2>
     <form id="addStudentForm">
       <input type="hidden" name="cellId" th:value="${formDto.cell.id}"/>
@@ -105,27 +96,8 @@
     </form>
   </div>
 </div>
-<div id="toast" style="
-  visibility: hidden;
-  min-width: 200px;
-  background-color: #333;
-  color: #fff;
-  text-align: center;
-  border-radius: 12px;
-  padding: 16px 24px;
-  position: fixed;
-  z-index: 9999;
-  left: 50%;
-  bottom: 80px;
-  transform: translateX(-50%);
-  font-size: 1.1rem;
-  font-weight: bold;
-  box-shadow: 0 6px 20px rgba(0,0,0,0.2);
-  transition: opacity 0.5s ease, visibility 0.5s;
-  opacity: 0;
-"></div>
 
-<!--<div th:replace="~{nav :: bottom-nav}"></div>-->
+<div id="toast"></div>
 
 </body>
 </html>

--- a/attendance/src/main/resources/templates/attendance_form.html
+++ b/attendance/src/main/resources/templates/attendance_form.html
@@ -78,7 +78,7 @@
     </div>
   </div>
 
-  <button type="submit" th:text="${formDto.isEdit} ? '출결사항 수정' : '출결사항 제출'"></button>
+  <button type="submit" th:text="${formDto.isEdit} ? '수정' : '제출'"></button>
 
 </form>
 <!--친구추가 모달-->

--- a/attendance/src/main/resources/templates/attendance_records.html
+++ b/attendance/src/main/resources/templates/attendance_records.html
@@ -14,12 +14,14 @@
 
 <body>
 
+<div class="title-container">
 <h1>
   <a th:href="@{/attendance/records}">💾 출석 내역 조회</a>
 </h1>
+</div>
 
 <form th:action="@{/attendance/records}" method="get" class="filter-section">
-  <select name="date" id="date" required onchange="this.form.submit()">
+  <select name="date" id="date" required onchange="this.form.submit()" class="form-control">
     <option value="" disabled selected>날짜를 선택하세요</option>
     <option th:each="date : ${dates}" th:value="${#temporals.format(date, 'yyyy-MM-dd')}"
             th:text="${#temporals.format(date, 'yyyy-MM-dd')}"

--- a/attendance/src/main/resources/templates/attendance_records.html
+++ b/attendance/src/main/resources/templates/attendance_records.html
@@ -19,7 +19,6 @@
 </h1>
 
 <form th:action="@{/attendance/records}" method="get" class="filter-section">
-  <label for="date">날짜 :</label>
   <select name="date" id="date" required onchange="this.form.submit()">
     <option value="" disabled selected>날짜를 선택하세요</option>
     <option th:each="date : ${dates}" th:value="${#temporals.format(date, 'yyyy-MM-dd')}"
@@ -32,7 +31,7 @@
 
 <div th:if="${summaryList != null} and ${attendances} == null">
   <div class="summary-header">
-    <h3 style="margin: 0;">📢 오늘의 출석 요약</h3>
+    <h3>📢 오늘의 출석 요약</h3>
     <button class="scroll-button"
             onclick="window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });">⬇
     </button>
@@ -68,7 +67,7 @@
           </thead>
           <tbody>
           <tr th:if="${#lists.isEmpty(entry.value.attendanceList)}">
-            <td colspan="3" style="font-style: italic;">아직 출석 정보가 없습니다.</td>
+            <td colspan="3" class="no-attendance">아직 출석 정보가 없습니다.</td>
           </tr>
           <tr th:each="att : ${entry.value.attendanceList}">
             <td th:text="${att.student.name}"></td>

--- a/attendance/src/main/resources/templates/select_cell.html
+++ b/attendance/src/main/resources/templates/select_cell.html
@@ -14,7 +14,7 @@
 
 <div style="position: relative;">
   <h1>🏠 출석부</h1>
-  <p th:if="${!isSunday}" class="warning-card">
+  <p th:if="${!isSunday}" class="not-sunday">
     출석 체크는 일요일에만 가능
   </p>
 </div>

--- a/attendance/src/main/resources/templates/select_cell.html
+++ b/attendance/src/main/resources/templates/select_cell.html
@@ -49,37 +49,6 @@
 <div th:if="${success}" class="message message-success" th:text="${success}"></div>
 <div th:if="${error}" class="message message-error" th:text="${error}"></div>
 
-<!--&lt;!&ndash; 셀 테이블 &ndash;&gt;-->
-<!--<table>-->
-<!--  <thead>-->
-<!--  <tr>-->
-<!--    <th>셀</th>-->
-<!--    <th>교사</th>-->
-<!--    <th>제출 여부</th>-->
-<!--    <th></th>-->
-<!--  </tr>-->
-<!--  </thead>-->
-<!--  <tbody>-->
-<!--  <tr th:each="cell : ${cells}">-->
-<!--    <td th:text="${cell.name}">셀 이름</td>-->
-<!--    <td th:text="${cell.teacher}">교사 이름</td>-->
-<!--    <td th:text="${attendanceStatusMap[cell.id] ? '✅' : '❌'}"-->
-<!--        th:classappend="${attendanceStatusMap[cell.id]} ? 'status-submitted' : 'status-pending'"></td>-->
-<!--    <td>-->
-<!--      <form th:if="${!attendanceStatusMap[cell.id]}" th:action="@{/attendance/form}" method="get">-->
-<!--        <input type="hidden" name="cellId" th:value="${cell.id}"/>-->
-<!--        <button type="submit" class="btn btn-submit" th:disabled="${!isSunday}">출석</button>-->
-<!--      </form>-->
-<!--      <form th:if="${attendanceStatusMap[cell.id]}" th:action="@{/attendance/edit}" method="get">-->
-<!--        <input type="hidden" name="cellId" th:value="${cell.id}"/>-->
-<!--        <button type="submit" class="btn btn-edit" th:disabled="${!isSunday}">수정</button>-->
-<!--      </form>-->
-<!--    </td>-->
-<!--  </tr>-->
-<!--  </tbody>-->
-<!--</table>-->
-
-
 <!-- 최근 수정시간 -->
 <div th:if="${lastUpdatedTime != null and isSunday}" style="text-align: center; margin-top: 10px;">
   <p>
@@ -87,15 +56,6 @@
     <span th:text="${#temporals.format(lastUpdatedTime, 'yyyy-MM-dd HH:mm')}"></span>
     (<span th:text="${lastUpdatedCellName}"></span>)
   </p>
-</div>
-
-<!-- 예외 모달 -->
-<div id="errorModal" style="display: none; position: fixed; top: 0; left: 0;
-  width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; align-items: center; justify-content: center;">
-  <div style="background: white; padding: 20px 30px; border-radius: 10px; text-align: center;">
-    <p id="modalErrorMessage" style="margin-bottom: 20px;"></p>
-    <button onclick="closeModal()">확인</button>
-  </div>
 </div>
 
 <div th:replace="~{nav :: bottom-nav}"></div>

--- a/attendance/src/main/resources/templates/select_cell.html
+++ b/attendance/src/main/resources/templates/select_cell.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<div style="position: relative;">
+<div style="text-align:center;">
   <h1>🏠 출석부</h1>
   <p th:if="${!isSunday}" class="not-sunday">
     출석 체크는 일요일에만 가능
@@ -20,7 +20,7 @@
 </div>
 
 <!-- 출석 집계 현황 -->
-<div style="margin-top: 20px; text-align: center;">
+<div style="margin-top: 8px; text-align: center;">
   <p th:if="${allSubmitted}" style="font-weight: bold; font-size: 1.3rem;">
     ☑️ 전체 출석 인원: <span th:text="${todayPresentCount}"></span>명
   </p>
@@ -51,7 +51,7 @@
 <div th:if="${chulcheckErrorMessage}" class="message exception-error" th:text="${chulcheckErrorMessage}"></div>
 
 <!-- 최근 수정시간 -->
-<div th:if="${lastUpdatedTime != null and isSunday}" style="text-align: center; margin-top: 10px;">
+<div th:if="${lastUpdatedTime != null and isSunday}" style="text-align: center; margin-top: 30px;">
   <p>
     🕓 마지막 수정:
     <span th:text="${#temporals.format(lastUpdatedTime, 'yyyy-MM-dd HH:mm')}"></span>

--- a/attendance/src/main/resources/templates/select_cell.html
+++ b/attendance/src/main/resources/templates/select_cell.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<div style="text-align:center;">
+<div class="title-container">
   <h1>🏠 출석부</h1>
   <p th:if="${!isSunday}" class="not-sunday">
     출석 체크는 일요일에만 가능

--- a/attendance/src/main/resources/templates/select_cell.html
+++ b/attendance/src/main/resources/templates/select_cell.html
@@ -45,9 +45,10 @@
   </form>
 </div>
 
-<!-- 메시지 -->
+<!-- 토스트 메시지 -->
 <div th:if="${success}" class="message message-success" th:text="${success}"></div>
 <div th:if="${error}" class="message message-error" th:text="${error}"></div>
+<div th:if="${chulcheckErrorMessage}" class="message exception-error" th:text="${chulcheckErrorMessage}"></div>
 
 <!-- 최근 수정시간 -->
 <div th:if="${lastUpdatedTime != null and isSunday}" style="text-align: center; margin-top: 10px;">


### PR DESCRIPTION
# [변경 사항]
1. feat: 예외 메시지 출력을 모달 -> toast 변경
   - 존재하지 않는 셀id를 사용하여 url로 바로 접근시의, 예외 메시지 출력 방식을 모달에서 토스트로 변경
2. 각 css 파일에서 nav바와 관련된 부분들을 nav의 css 파일로 이동
3. 이미 제출되었음에도 재제출을 할 경우, 수정 화면으로 리다이렉트 되도록 수정
   - (제출-제출) 플로우가 아니라 (제출-수정) 플로우로 갈 수 있도록 수정
4. 결석사유 입력칸이 박스 내부에 들어가지 않고 밖으로 튀어나오는 이슈 해결
5. records 화면에서 셀별 테이블 주변 백그라운트 컬러 추가, 타이틀 위치 통일