### PR TITLE
feat :  출석 내역조회 화면에 특정 날짜의 총 출석수 추가

### DIFF
--- a/attendance/src/main/java/smmiddle/attendance/controller/RecordController.java
+++ b/attendance/src/main/java/smmiddle/attendance/controller/RecordController.java
@@ -18,6 +18,7 @@ import smmiddle.attendance.dto.RecordDto;
 import smmiddle.attendance.entity.Attendance;
 import smmiddle.attendance.entity.Cell;
 import smmiddle.attendance.service.AttendanceService;
+import smmiddle.attendance.service.RecordService;
 
 @Controller
 @RequiredArgsConstructor
@@ -25,13 +26,14 @@ import smmiddle.attendance.service.AttendanceService;
 public class RecordController {
 
   private final AttendanceService attendanceService;
+  private final RecordService recordService;
 
 
   @GetMapping("/attendance/records")
   public String viewAttendanceRecords(
       HttpSession session,
-      //@RequestParam(name = "cellId", required = false) Long cellId,
-      @RequestParam(name = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+      @RequestParam(name = "date", required = false)
+      @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
       Model model) {
 
     if (isNotAuthenticated(session)) {
@@ -44,17 +46,17 @@ public class RecordController {
     model.addAttribute("cells", cells);
 
     // 날짜 목록 전달 (출석 기록 있는 날짜만)
-    List<LocalDate> attendanceDates = attendanceService.getAllAttendanceDates();
+    List<LocalDate> attendanceDates = recordService.getAllAttendanceDates();
     model.addAttribute("dates", attendanceDates);
 
     // 날짜 또는 셀이 선택되지 않은 경우, 전체 셀 출결 요약
     if (date == null) {
-      List<CellAttendanceSummaryDto> summaryList = attendanceService.getTodayCellAttendanceSummary();
+      List<CellAttendanceSummaryDto> summaryList = recordService.getTodayCellAttendanceSummary();
       model.addAttribute("summaryList", summaryList);
       return "attendance_records";
     }
 
-    Map<Cell, RecordDto> cellAttendanceMap = attendanceService.getAllCellsAttendanceByDateWithCount(date);
+    Map<Cell, RecordDto> cellAttendanceMap = recordService.getAllCellsAttendanceByDateWithCount(date);
     model.addAttribute("cellAttendanceMap", cellAttendanceMap);
     model.addAttribute("selectedDate", date.toString());
 

--- a/attendance/src/main/java/smmiddle/attendance/controller/RecordController.java
+++ b/attendance/src/main/java/smmiddle/attendance/controller/RecordController.java
@@ -60,6 +60,9 @@ public class RecordController {
     model.addAttribute("cellAttendanceMap", cellAttendanceMap);
     model.addAttribute("selectedDate", date.toString());
 
+    long totalPresentAndAllowedCount = recordService.getTotalPresentAndAllowedCountByDate(date);
+    model.addAttribute("totalPresentAndAllowedCount", totalPresentAndAllowedCount);
+
     return "attendance_records";
   }
 }

--- a/attendance/src/main/java/smmiddle/attendance/repository/AttendanceRepository.java
+++ b/attendance/src/main/java/smmiddle/attendance/repository/AttendanceRepository.java
@@ -22,4 +22,6 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
   Optional<Attendance> findTopByUpdatedDateIsNotNullOrderByUpdatedDateDesc();
 
   Optional<Attendance> findTopByStudent_IdOrderByDateDesc(Long studentId);
+
+  List<Attendance> findByDate(LocalDate date);
 }

--- a/attendance/src/main/java/smmiddle/attendance/service/RecordService.java
+++ b/attendance/src/main/java/smmiddle/attendance/service/RecordService.java
@@ -51,6 +51,16 @@ public class RecordService {
   }
 
   /**
+   * 특정 날짜의 전체 출석 합계
+   */
+  public long getTotalPresentAndAllowedCountByDate(LocalDate date) {
+    List<Attendance> attendances = attendanceRepository.findByDate(date);
+    return attendances.stream()
+        .filter(attendanceService::countsAsPresent)
+        .count();
+  }
+
+  /**
    * 출결정보 조회 화면의 요약본
    */
   public List<CellAttendanceSummaryDto> getTodayCellAttendanceSummary() {

--- a/attendance/src/main/java/smmiddle/attendance/service/RecordService.java
+++ b/attendance/src/main/java/smmiddle/attendance/service/RecordService.java
@@ -1,0 +1,81 @@
+package smmiddle.attendance.service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import smmiddle.attendance.dto.CellAttendanceSummaryDto;
+import smmiddle.attendance.dto.RecordDto;
+import smmiddle.attendance.entity.Attendance;
+import smmiddle.attendance.entity.Cell;
+import smmiddle.attendance.repository.AttendanceRepository;
+import smmiddle.attendance.repository.CellRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecordService {
+
+  private final AttendanceService attendanceService;
+  private final AttendanceRepository attendanceRepository;
+  private final CellRepository cellRepository;
+
+  /**
+   * 출석이 저장된 모든 날짜 목록 조회
+   */
+  public List<LocalDate> getAllAttendanceDates() {
+    return attendanceRepository.findDistinctDates();
+  }
+
+
+  /**
+   * 특정 날짜의 모든 셀의 출결사항 조회 & 각 셀의 총 출석수 조회
+   */
+  public Map<Cell, RecordDto> getAllCellsAttendanceByDateWithCount(LocalDate date) {
+    List<Cell> cells = cellRepository.findAll();
+    Map<Cell, RecordDto> result = new LinkedHashMap<>();
+
+    for (Cell cell : cells) {
+      List<Attendance> attList = attendanceService.getAttendancesByCellIdAndDate(cell.getId(), date);
+      long presentCount = attList.stream()
+          .filter(attendanceService::countsAsPresent)
+          .count();
+      result.put(cell, new RecordDto(attList, presentCount));
+    }
+
+    return result;
+  }
+
+  /**
+   * 출결정보 조회 화면의 요약본
+   */
+  public List<CellAttendanceSummaryDto> getTodayCellAttendanceSummary() {
+    LocalDate today = LocalDate.now();
+    List<Cell> cells = cellRepository.findAll();
+    List<CellAttendanceSummaryDto> summaries = new ArrayList<>();
+
+    for (Cell cell : cells) {
+      boolean submitted = attendanceRepository.existsByStudent_Cell_IdAndDate(cell.getId(), today);
+
+      String presentCountDisplay;
+      if (submitted) {
+        List<Attendance> attendances = attendanceRepository.findByStudent_Cell_IdAndDateOrderByStudent_NameAsc(cell.getId(), today);
+        long presentCount = attendances.stream()
+            .filter(attendanceService::countsAsPresent)
+            .count();
+        presentCountDisplay = presentCount + "명";
+      } else {
+        presentCountDisplay = "⌛";
+      }
+
+      summaries.add(new CellAttendanceSummaryDto(cell.getName(), submitted, presentCountDisplay));
+    }
+
+    return summaries;
+  }
+
+}

--- a/attendance/src/main/resources/static/css/record.css
+++ b/attendance/src/main/resources/static/css/record.css
@@ -69,6 +69,12 @@ button[type="submit"] {
   padding: 10px 20px;
 }
 
+.date-summary {
+  text-align: center;
+  font-size: 1.3rem;
+  font-weight: bold;
+}
+
 hr {
   border: none;
   border-top: 1px solid #ddd;

--- a/attendance/src/main/resources/templates/attendance_records.html
+++ b/attendance/src/main/resources/templates/attendance_records.html
@@ -29,6 +29,12 @@
   </select>
 </form>
 
+<div th:if="${selectedDate != null}" class="date-summary">
+  <p>📊 총
+    <strong><span th:text="${totalPresentAndAllowedCount}"></span></strong>
+    명 출석</p>
+</div>
+
 <hr/>
 
 <div th:if="${summaryList != null} and ${attendances} == null">


### PR DESCRIPTION
# [변경 사항]
- 출석 내역조회 화면에서 특정 날짜를 선택하면 
해당 날짜의 출석(PRESENT, ALLOWED) 수를 보여주는 기능을 추가했습니다.  
- AttendanceService 클래스 내에 있던 출석 내역조회 관련된 코드들을 RecordService 클래스로 이동하여 역할을 분리했습니다. 