### PR TITLE
feat : 날짜별로 출석부 미제출 셀을 확인할 수 있도록 기능 추가

### DIFF
--- a/attendance/src/main/java/smmiddle/attendance/controller/RecordController.java
+++ b/attendance/src/main/java/smmiddle/attendance/controller/RecordController.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import smmiddle.attendance.dto.AllAttendanceSummaryDto;
 import smmiddle.attendance.dto.CellAttendanceSummaryDto;
 import smmiddle.attendance.dto.RecordDto;
 import smmiddle.attendance.entity.Attendance;
@@ -60,8 +61,9 @@ public class RecordController {
     model.addAttribute("cellAttendanceMap", cellAttendanceMap);
     model.addAttribute("selectedDate", date.toString());
 
-    long totalPresentAndAllowedCount = recordService.getTotalPresentAndAllowedCountByDate(date);
-    model.addAttribute("totalPresentAndAllowedCount", totalPresentAndAllowedCount);
+    // 선택된 날짜 기준 출석 요약
+    AllAttendanceSummaryDto summary = attendanceService.getAttendanceSummary(date);
+    model.addAttribute("summary", summary);
 
     return "attendance_records";
   }

--- a/attendance/src/main/java/smmiddle/attendance/dto/AllAttendanceSummaryDto.java
+++ b/attendance/src/main/java/smmiddle/attendance/dto/AllAttendanceSummaryDto.java
@@ -1,5 +1,6 @@
 package smmiddle.attendance.dto;
 
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +10,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AllAttendanceSummaryDto {
   private final Map<Long, Boolean> attendanceStatusMap; // 셀별 출석 제출 여부
-  private final boolean allSubmitted; // 전체 셀 제출 여부
+  private final boolean allSubmitted; // 전체 셀 출석부 제출 여부
+  private List<String> unsubmittedCells; // 출석부 미제출 셀 리스트
   private final int todayPresentCount; // 오늘 총 출석수
 
 }

--- a/attendance/src/main/java/smmiddle/attendance/service/AttendanceService.java
+++ b/attendance/src/main/java/smmiddle/attendance/service/AttendanceService.java
@@ -2,6 +2,7 @@ package smmiddle.attendance.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -111,18 +112,25 @@ public class AttendanceService {
     Map<Long, Boolean> attendanceStatusMap = new HashMap<>();
     boolean allSubmitted = true;
     int todayPresentCount = 0;
+    List<String> unsubmittedCells = new ArrayList<>();
 
     for (Cell cell : cells) {
       boolean submitted = alreadySubmitted(cell.getId(), today);
       attendanceStatusMap.put(cell.getId(), submitted);
       if (!submitted) {
         allSubmitted = false;
+        unsubmittedCells.add(cell.getName());  // 미제출 셀
       } else {
         todayPresentCount += getTodayPresentCount(cell.getId(), today);
       }
     }
 
-    return new AllAttendanceSummaryDto(attendanceStatusMap, allSubmitted, todayPresentCount);
+    return new AllAttendanceSummaryDto(
+        attendanceStatusMap,
+        allSubmitted,
+        unsubmittedCells,
+        todayPresentCount
+    );
   }
 
   /**

--- a/attendance/src/main/java/smmiddle/attendance/service/RecordService.java
+++ b/attendance/src/main/java/smmiddle/attendance/service/RecordService.java
@@ -50,15 +50,15 @@ public class RecordService {
     return result;
   }
 
-  /**
-   * 특정 날짜의 전체 출석 합계
-   */
-  public long getTotalPresentAndAllowedCountByDate(LocalDate date) {
-    List<Attendance> attendances = attendanceRepository.findByDate(date);
-    return attendances.stream()
-        .filter(attendanceService::countsAsPresent)
-        .count();
-  }
+//  /**
+//   * 특정 날짜의 전체 출석 합계
+//   */
+//  public long getTotalPresentAndAllowedCountByDate(LocalDate date) {
+//    List<Attendance> attendances = attendanceRepository.findByDate(date);
+//    return attendances.stream()
+//        .filter(attendanceService::countsAsPresent)
+//        .count();
+//  }
 
   /**
    * 출결정보 조회 화면의 요약본

--- a/attendance/src/main/resources/static/css/record.css
+++ b/attendance/src/main/resources/static/css/record.css
@@ -75,6 +75,12 @@ button[type="submit"] {
   font-weight: bold;
 }
 
+.date-summary .unsubmitted {
+  font-size: 1rem;
+  font-weight: normal;
+  color: #555;
+}
+
 hr {
   border: none;
   border-top: 1px solid #ddd;

--- a/attendance/src/main/resources/templates/attendance_records.html
+++ b/attendance/src/main/resources/templates/attendance_records.html
@@ -29,10 +29,20 @@
   </select>
 </form>
 
-<div th:if="${selectedDate != null}" class="date-summary">
-  <p>📊 총
-    <strong><span th:text="${totalPresentAndAllowedCount}"></span></strong>
-    명 출석</p>
+<!--<div th:if="${selectedDate != null}" class="date-summary">-->
+<!--  <p>📊 총-->
+<!--    <strong><span th:text="${totalPresentAndAllowedCount}"></span></strong>-->
+<!--    명 출석</p>-->
+<!--</div>-->
+
+<div th:if="${selectedDate != null and summary != null}" class="date-summary">
+  <p>📊 총 <strong th:text="${summary.todayPresentCount}"></strong> 명 출석</p>
+  <p th:if="${summary.unsubmittedCells != null and !summary.unsubmittedCells.isEmpty()}"
+     class="unsubmitted">
+    (⚠️ 미제출 셀 :
+    <span th:text="${#strings.listJoin(summary.unsubmittedCells, ', ')}"></span>
+    )
+  </p>
 </div>
 
 <hr/>


### PR DESCRIPTION
# [변경 사항]
- getTotalPresentAndAllowedCountByDate 사용 대신, AllAttendanceSummaryDto를 보완하여 attendanceService.getAttendanceSummary(date)의 기능을 확장했습니다. 
  - 이로 인해 특정 날짜의 전체 출석 합계를 따로 구하는 메서드를 사용할 필요가 없게 되었습니다. 
  - 대신, 확장된 Dto 사용으로 총출석수와 함께 출석부를 제출하지 않은 반의 리스트도 확인할 수 있도록 하였습니다. 